### PR TITLE
meson: Add basic meson build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,23 @@ How to compile under Linux:
 
 I did not have time to test the newest version of the tools under Linux. These instructions are for the older versions (v7.3 and below).
 
-Install gcc-c++ (g++) compiler, cmake, git and any wxGTK-devel v.2.9+ package available for your distribution repository. There is one program which requires wxWidgets - DeserializeAll. Everything else should compile perfectly without wxGTK installed.
+Install gcc-c++ (g++) compiler, meson, ninja, git and any wxGTK-devel v.2.9+ package available for your distribution repository.
+There are some programs which requires wxWidgets:
+ - DecompressLZO
+ - DeserializeAll
+ - ExportTexturesToDDS
+ - ImportTexturesFromDDS
+
+Everything else should compile perfectly without wxGTK installed.
 
 Clone github repo and compile UPKUtils project:
 ```
 git clone https://github.com/wghost/UPKUtils.git
-cd UPKUtils/build
-cmake .
-make
+meson build
+cd build
+ninja
 ```
+
 To compile XComLZO packer/unpacker (deprecated):
 ```
 cd UPKUtils/XComLZO/build

--- a/meson.build
+++ b/meson.build
@@ -4,25 +4,6 @@ project('UPKUtils',
   version : '1.6',
   meson_version : '>=0.49')
 
-# also search in the project base dir
-inc = [ include_directories('.') ]
-
-common_headers = files([
-  'CustomTFC.h',
-  'lzoconf.h',
-  'lzodefs.h',
-  'LzoUtils.h',
-  'minilzo.h',
-  'UFlags.h',
-  'UObjectFactory.h',
-  'UObject.h',
-  'UPKInfo.h',
-  'UPKUtils.h',
-  'UToken.h',
-  'UTokenFactory.h',
-])
-#install_headers(common_headers)
-
 common_src = [
   'CustomTFC.cpp',
   'LzoUtils.cpp',

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,99 @@
+project('UPKUtils',
+  [ 'cpp', 'c' ],
+  default_options : [ 'cpp_std=c++14' ],
+  version : '1.6',
+  meson_version : '>=0.49')
+
+# also search in the project base dir
+inc = [ include_directories('.') ]
+
+common_headers = files([
+  'CustomTFC.h',
+  'lzoconf.h',
+  'lzodefs.h',
+  'LzoUtils.h',
+  'minilzo.h',
+  'UFlags.h',
+  'UObjectFactory.h',
+  'UObject.h',
+  'UPKInfo.h',
+  'UPKUtils.h',
+  'UToken.h',
+  'UTokenFactory.h',
+])
+#install_headers(common_headers)
+
+common_src = [
+  'CustomTFC.cpp',
+  'LzoUtils.cpp',
+  'minilzo.c',
+  'UFlags.cpp',
+  'UObject.cpp',
+  'UObjectFactory.cpp',
+  'UPKInfo.cpp',
+  'UPKUtils.cpp',
+  'UToken.cpp',
+  'UTokenFactory.cpp',
+]
+libcommon = static_library('common', common_src)
+
+# required by some of the binaries
+wx_dep = dependency('wxwidgets',
+  version : '>=3.0.0',
+  required : true,
+  modules : ['std', 'stc'])
+
+if wx_dep.found()
+  executable('DecompressLZO',
+    ['DecompressLZO.cpp'],
+    link_with: libcommon,
+    dependencies : wx_dep)
+
+  executable('DeserializeAll',
+    ['DeserializeAll.cpp'],
+    link_with: libcommon,
+    dependencies : wx_dep)
+
+  executable('ExportTexturesToDDS',
+    ['ExportTexturesToDDS.cpp', 'dds.cpp'],
+    link_with: libcommon,
+    dependencies : wx_dep)
+
+  executable('ImportTexturesFromDDS',
+    ['ImportTexturesFromDDS.cpp', 'dds.cpp'],
+    link_with: libcommon,
+    dependencies : wx_dep)
+endif
+
+executable('CompareUPK',
+  ['CompareUPK.cpp', 'UPKInfo.cpp', 'UFlags.cpp'])
+
+executable('ExtractNameLists',
+  ['ExtractNameLists.cpp'],
+  link_with: libcommon)
+
+executable('FindObjectByOffset',
+  ['FindObjectByOffset.cpp'],
+  link_with: libcommon)
+
+executable('FindObjectEntry',
+  ['FindObjectEntry.cpp'],
+  link_with: libcommon)
+
+executable('HexToPseudoCode',
+  ['HexToPseudoCode.cpp'],
+  link_with: libcommon)
+
+executable('MoveExpandFunction',
+  ['MoveExpandFunction.cpp'],
+  link_with: libcommon)
+
+executable('ParseTfc',
+  ['ParseTfc.cpp', 'dds.cpp'],
+  link_with: libcommon)
+
+executable('PatchUPK',
+  ['PatchUPK.cpp', 'ModParser.cpp', 'ModScript.cpp'],
+  link_with: libcommon)
+
+executable('UENativeTablesReader', ['UENativeTablesReader.cpp'])


### PR DESCRIPTION
Apparently the CMake support is outdated and does not work anymore. And it is kind of inconvenient to install CodeBlocks, just to build the project.

This will add a minimal meson.build file to allow building all targets known to Codeblocks.
And it updates the documentation accord to the changes.