### PR TITLE
Fix CreatePath stall/leak

### DIFF
--- a/DeserializeAll.cpp
+++ b/DeserializeAll.cpp
@@ -13,7 +13,7 @@ string CreatePath(string fullName, string dirName)
 {
     string str = fullName;
     vector<string> names;
-    unsigned pos = str.find('.');
+    std::size_t pos = str.find('.');
     if (pos == string::npos)
         return (dirName + "\\" + str + ".txt");
     while (pos != string::npos)


### PR DESCRIPTION
`str.find` returns a `std::size_t`  which is afaik either 32 or 64-bit. But this is truncated down to an `unsigned` which (also afaik) is always 32-bit. As `string::npos` is also a `std::size_t`, `pos == string::npos` can sometimes be comparing `4294967295` (the 32-bit max) and  `18446744073709551615` (the 64-bit max). This causes it to infinitely loop and eventually run out of memory due to `names.push_back`.
